### PR TITLE
Send photos urls from each item to render it in the json

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,11 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
 
+    @items.each do |item|
+      # Set the first photo from the item photos as the image_url to be displayed in the home page.
+      item.image_url = item.photos[0].url if item.photos.attached?
+    end
+
     render json: ItemBlueprint.render(@items)
   end
 
@@ -13,8 +18,11 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    item_photos_urls = []
 
-    render json: ItemBlueprint.render(@item)
+    @item.photos.each { |photo| item_photos_urls << photo.url }
+
+    render json: {item: @item, photos_urls: item_photos_urls }
   end
 
   def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,5 @@ class Item < ApplicationRecord
   has_many_attached :photos
   belongs_to :user
   has_many :reservations
+
 end


### PR DESCRIPTION
- In the items index, attach the first photo url as the image_url attribute, so it can be used to populate the item card in the home page.
- In the item show, loop through the photos and generate each url, and send them to an items_photos_urls that is rendered as json. 